### PR TITLE
chore(datadog): use environment variables in constructor

### DIFF
--- a/examples/worker/src/index.ts
+++ b/examples/worker/src/index.ts
@@ -4,6 +4,7 @@ export interface Env {
 	// Datadog API keys
 	DD_API_KEY?: string;
 	DATADOG_API_KEY?: string;
+	DD_SITE?: string;
 }
 
 export default {


### PR DESCRIPTION
# What?

Couple small performance improvements for the Datadog Sink.

1. Ensures environment variables are only read once during the constructor.
a. Logs error when API key is not set.
b. Changes priority to: options > `DD_API_KEY` > `DATADOG_API_KEY`
2. Skips sending payload when no API key is set.
a. Warns that metrics are dropped.
3. Introduces `DD_SITE`.

# Notes

In general, Datadog doesn't recommend `DATADOG_API_KEY`, but I'm currently keeping it, as opposed to remove it. I'm just not recommending it in the logs.
